### PR TITLE
Updating to hapi17 compatability.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ node_js:
 
 services:
   - mongodb
+
+after_script: "npm run coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 
 node_js:
-  - "6"
+  - "8"
+  - "9"
 
 services:
   - mongodb

--- a/index.js
+++ b/index.js
@@ -1,30 +1,28 @@
 'use strict';
 
-exports.register = (server, opts, next) => {
-  if (!opts.collections) {
-    return next();
-  }
+exports.plugin = {
+  async register(server, opts) {
+    if (!opts.collections) {
+      return;
+    }
 
-  let db;
+    let db;
 
-  if (server.mongo && typeof server.mongo.db === 'object') {
-    db = server.mongo.db;
-  } else {
-    db = server.plugins['hapi-mongodb'].db;
-  }
+    if (server.mongo && typeof server.mongo.db === 'object') {
+      db = server.mongo.db;
+    } else {
+      db = server.plugins['hapi-mongodb'].db;
+    }
 
-  Object.keys(opts.collections).forEach(index => {
-    const collectionConfig = opts.collections[index];
-    const collection = db.collection(index);
-    collectionConfig.forEach(indexConfig => {
-      collection.createIndex(indexConfig.keys, indexConfig.options || { background: true }, err => {
-        server.log(['hapi-mongo-indexes'], err);
+    Object.keys(opts.collections).forEach(index => {
+      const collectionConfig = opts.collections[index];
+      const collection = db.collection(index);
+      collectionConfig.forEach(indexConfig => {
+        collection.createIndex(indexConfig.keys, indexConfig.options || { background: true }, err => {
+          server.log(['hapi-mongo-indexes'], err);
+        });
       });
     });
-  });
-  next();
-};
-
-exports.register.attributes = {
+  },
   pkg: require('./package.json')
 };

--- a/package.json
+++ b/package.json
@@ -4,17 +4,17 @@
   "description": "Ensures indexes",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "lab -C"
   },
   "author": "First+Third",
   "license": "MIT",
   "devDependencies": {
-    "chai": "^3.5.0",
+    "code": "^5.1.2",
     "eslint": "^3.9.1",
     "eslint-config-firstandthird": "^3.0.2",
     "eslint-plugin-import": "^2.1.0",
-    "hapi": "^16.0.2",
-    "hapi-mongodb": "^6.2.0",
-    "mocha": "^3.1.2"
+    "hapi": "^17.2.0",
+    "hapi-mongodb": "^7.1.0",
+    "lab": "^15.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,12 +4,14 @@
   "description": "Ensures indexes",
   "main": "index.js",
   "scripts": {
-    "test": "lab -C"
+    "test": "lab --leaks -e test -c",
+    "coveralls": "lab -r lcov | coveralls"
   },
   "author": "First+Third",
   "license": "MIT",
   "devDependencies": {
     "code": "^5.1.2",
+    "coveralls": "^3.0.0",
     "eslint": "^3.9.1",
     "eslint-config-firstandthird": "^3.0.2",
     "eslint-plugin-import": "^2.1.0",


### PR DESCRIPTION
Updated plugin for hapi-17 compatabillity.
Also:
- Removed `mocha` / `chai` testing framework.
- Replaced with `async` / `await` compatible `lab` / `code`
- Rewrote tests in `async` / `await` style.